### PR TITLE
spawn usage needs O_CLOEXEC

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "devDependencies": {
     "jscs": "^1.13.1",
     "jshint": "^2.8.0",
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "through2": "^2.0.1"
   },
   "main": "./lib",
   "scripts": {
@@ -33,4 +34,3 @@
     "node": ">= 0.12.0"
   }
 }
-

--- a/src/posix.cc
+++ b/src/posix.cc
@@ -7,6 +7,7 @@
 #include <process.h>
 #else
 #include <unistd.h>
+#include <fcntl.h>
 #endif
 #include <v8.h>
 
@@ -21,6 +22,16 @@ void Pipe(const FunctionCallbackInfo<Value>& args) {
 #else
     int pipefd[2];
     int ret = pipe(pipefd);
+    if (ret == -1) {
+        args.GetReturnValue().Set(Undefined(isolate));
+        return;
+    }
+    ret = fcntl(pipefd[0], F_SETFD, FD_CLOEXEC);
+    if (ret == -1) {
+        args.GetReturnValue().Set(Undefined(isolate));
+        return;
+    }
+    ret = fcntl(pipefd[1], F_SETFD, FD_CLOEXEC);
     if (ret == -1) {
         args.GetReturnValue().Set(Undefined(isolate));
         return;

--- a/test/pipe-test.js
+++ b/test/pipe-test.js
@@ -84,6 +84,7 @@ describe('pipe channel', function() {
     var p = pipe();
     var proc = spawn('cat', [ '/dev/stdin' ],
         { stdio: [ p[0], 'pipe', 'pipe' ] })
+    p[0].destroy();
     var hasData = false;
     proc.stdout.pipe(through(function(chunk, _, cb) {
       hasData = true;
@@ -94,7 +95,6 @@ describe('pipe channel', function() {
       assert.equal(hasData, true,
         'data should have been received')
       cb()
-      p[0].destroy();
       p[1].destroy();
       delete p
       done()


### PR DESCRIPTION
Hello,

I have been trying to solve an issue when spawning some linux binaries that need to use `/dev/stdin`.
It does not work in node.js and the root cause of the problem comes from the explanation on https://github.com/nodejs/node-v0.x-archive/issues/3530

Basically, node.js uses socket instead of posix-pipes and most linux do not accept to open /dev/stdin when it is a socket.

using `posix-pipes` I could make it work, but the process was never ending. With help from @addaleax I could make it work by adding the O_CLOEXEC flag when opening the posix-pipes.

This PR adds this flag and a test showing that streaming works when spawning `cat /dev/stdin`.

Now I still have one (major) problem left in that the test randomly fails / succeed.

It seems to come from the fact that the written data is lost somewhere depending on some race condition but I could not figure out why and have no clue on how to debug it.

I send this PR in case anyone has any idea on how to go forward on this.
