### PR TITLE
Fix test: should pass data from child process

### DIFF
--- a/test/pipe-test.js
+++ b/test/pipe-test.js
@@ -102,7 +102,7 @@ describe('pipe channel', function () {
   })
   it('should pass data from child process', function (done) {
     var p = pipe()
-    var proc = spawn('cat', [ '/dev/stdin' ],
+    var proc = spawn('cat',
         { stdio: [ 'pipe', p[1], 'pipe' ] })
     proc.on('error', function (e) { throw e })
     p[1].destroy()


### PR DESCRIPTION
When using 'pipe' on stdin, node.js uses a socket, for which /dev/stdin cannot be opened.
This makes the test pass, but I could not find how to output the error.
